### PR TITLE
Hot iron recipes results in non-rusted products

### DIFF
--- a/data/metallurgy/metallurgy-d.lua
+++ b/data/metallurgy/metallurgy-d.lua
@@ -176,6 +176,7 @@ for _, metal in pairs{"steel", "iron", "copper"} do
 	plateRecipe.category = "crafting"
 	plateRecipe.auto_recycle = true -- Allowing it, so that on Fulgora you can unmake plates for cold ingots, then heat those, then make parts/rods/wires/etc.
 	plateRecipe.allow_as_intermediate = true
+	plateRecipe.result_is_always_fresh = true
 	plateRecipe.allow_decomposition = true
 end
 

--- a/data/metallurgy/metallurgy-d.lua
+++ b/data/metallurgy/metallurgy-d.lua
@@ -191,6 +191,7 @@ for _, vals in pairs{
 	recipe.results = {{type="item", name=item, amount=num}}
 	recipe.energy_required = seconds
 	recipe.auto_recycle = true
+	recipe.result_is_always_fresh = true
 	recipe.category = "crafting"
 end
 


### PR DESCRIPTION
Hot iron spoils into fully fresh non-rusted cold iron.
But nearly spoilt hot iron recipes result in nearly rusted products.

This PR fixes that.