### PR TITLE
Move circuits to intermediates tab

### DIFF
--- a/data/broad-changes/item-groups.lua
+++ b/data/broad-changes/item-groups.lua
@@ -45,20 +45,28 @@ extend{
 		order = "b3",
 	},
 
+	-- Create subgroup for petroleum materials (plastic, rubber, etc.)
+	{
+		type = "item-subgroup",
+		name = "petroleum-materials",
+		group = "intermediate-products",
+		order = "c6",
+	},
+
+	-- Create subgroup for circuits
+	{
+		type = "item-subgroup",
+		name = "circuits",
+		group = "intermediate-products",
+		order = "c7",
+	},
+
 	-- Create subgroup for fluid logistics items.
 	{
 		type = "item-subgroup",
 		name = "fluid-logistics",
 		group = "logistics",
 		order = "d2",
-	},
-
-	-- Create subgroup for petroleum materials (plastic, rubber, etc.)
-	{
-		type = "item-subgroup",
-		name = "petroleum-materials",
-		group = "intermediate-products",
-		order = "c7",
 	},
 
 	-- Create item subgroup for all complex fluid recipes, meaning not just fractionation and cracking.
@@ -256,7 +264,7 @@ for i = 2, 3 do
 	moduleSubgroup.order = "g" .. i
 	extend{moduleSubgroup}
 end
-Gen.orderKinds("module", {ITEM, RECIPE}, {
+Gen.orderKinds("circuits", {ITEM, RECIPE}, {
 	"electronic-circuit",
 	"advanced-circuit",
 	"processing-unit",


### PR DESCRIPTION
It is fine if you reject this PR, but I think that non-primed circuits should really be in intermediates tab and not in Production tab. 

While it makes sense from this standpoint:
1. primed circuits should be in production tabs because they are modules
2. all circuits should be in one tab

I still think everybody looking for regular circuits will look in the intermediate tab. Not having all circuits in one place I think is fine.

This PR moves the recipes to the intermediates tab. (and also reorders the item subgroups definition so that different groups dont get mixed.)